### PR TITLE
Problem when mouse is clicked while dragging

### DIFF
--- a/spectrum.js
+++ b/spectrum.js
@@ -1091,7 +1091,7 @@
                     maxWidth = $(element).width();
                     offset = $(element).offset();
 
-                    $(doc).bind(duringDragEvents);
+                    $(doc.body).bind(duringDragEvents);
                     $(doc.body).addClass("sp-dragging");
 
                     move(e);


### PR DESCRIPTION
When you got out of the window (using Chrome) while draging and don't keep the mouse clicked outside the window until you go again into it, the drag function did not stop from that point on. After this fix you can stop it by clicking once more into the window.
